### PR TITLE
remove version from hashie

### DIFF
--- a/rash.gemspec
+++ b/rash.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.version = Rash::VERSION
 
-  s.add_dependency 'hashie', '~> 2.0.0'
+  s.add_dependency 'hashie'
   s.add_development_dependency 'rake', '~> 0.9'
   s.add_development_dependency 'rdoc', '~> 3.9'
   s.add_development_dependency 'rspec', '~> 2.5'


### PR DESCRIPTION
Because we should let people test with new versions and file bugs when things break.

Alternatively it would be a `>= 2.0` or a `~> 2.0` (two digits instead of three)

`~>` with 3 digits is just too restrictive.

For now I have to use the fork in order to be compatible with intridea/grape@HEAD
